### PR TITLE
baddie family: wall_crawler + dll_DB — 18 tiny helpers ported

### DIFF
--- a/include/main/dll/baddie/wall_crawler.h
+++ b/include/main/dll/baddie/wall_crawler.h
@@ -7,14 +7,18 @@ void FUN_8012ebbc(undefined8 param_1,undefined8 param_2,undefined8 param_3,undef
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8);
 void FUN_8012ecb8(undefined8 param_1,undefined8 param_2,undefined8 param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8);
-int FUN_8012ee7c(void);
+s32 fn_8012EE7C(void);
+void fn_8012EE88(void);
 void FUN_8012ee94(int param_1,undefined4 param_2,undefined4 param_3,int param_4);
-int FUN_8012f000(void);
+void fn_8012EF5C(void);
+s16 fn_8012EFA0(void);
+s32 fn_8012EFA8(void);
+s32 fn_8012F000(void);
 void FUN_8012f04c(undefined8 param_1,double param_2,double param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8,
                  undefined4 param_9,undefined4 param_10,undefined4 param_11,undefined4 param_12,
                  undefined4 param_13,undefined4 param_14,undefined4 param_15,undefined4 param_16);
-void FUN_8012f288(undefined2 param_1);
+void fn_8012F288(u16 param_1);
 void FUN_8012f298(undefined8 param_1,double param_2,double param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8,
                  undefined4 param_9,undefined4 param_10,uint param_11,undefined4 param_12,

--- a/src/main/dll/baddie/dll_DB.c
+++ b/src/main/dll/baddie/dll_DB.c
@@ -91,6 +91,18 @@ extern f32 FLOAT_803de56c;
 extern f32 FLOAT_803e2abc;
 extern f32 FLOAT_803e2e68;
 
+/* Narrowly-typed aliases for the sbss/sdata state vars this DLL owns. */
+extern u8 lbl_803DC6DA;
+extern u8 lbl_803DE408;
+extern u8 lbl_803DE409;
+extern u16 lbl_803DE418;
+extern s8 lbl_803DE434;
+extern s8 lbl_803DE568;
+extern s8 lbl_803DE570;
+extern s8 lbl_803DE574;
+extern u8 lbl_803DE578;
+extern u8 lbl_803DE579;
+
 /* Local declarations keep imported functions visible within the TU. */
 void FUN_8012fd0c(undefined8 param_1,double param_2,double param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8,
@@ -190,6 +202,13 @@ FUN_8012fe84(undefined8 param_1,double param_2,double param_3,undefined8 param_4
   return 0;
 }
 
+/* EN v1.0 Address: 0x8012FEE0  Size: 8b
+ * Setter for the sdata byte at lbl_803DC6DA. */
+void fn_8012FEE0(u8 param_1)
+{
+    lbl_803DC6DA = param_1;
+}
+
 /*
  * --INFO--
  *
@@ -236,8 +255,9 @@ void FUN_80130044(undefined8 param_1,undefined8 param_2,undefined8 param_3,undef
  * PAL Address: TODO
  * PAL Size: TODO
  */
-void FUN_80130110(undefined param_1)
+void fn_80130110(u8 param_1)
 {
+    lbl_803DE409 = param_1;
 }
 
 /*
@@ -252,11 +272,9 @@ void FUN_80130110(undefined param_1)
  * PAL Address: TODO
  * PAL Size: TODO
  */
-void FUN_80130118(void)
-
+void fn_80130118(void)
 {
-  DAT_803de408 = 0x3c;
-  return;
+    lbl_803DE408 = 0x3c;
 }
 
 /*
@@ -271,8 +289,9 @@ void FUN_80130118(void)
  * PAL Address: TODO
  * PAL Size: TODO
  */
-void FUN_80130124(undefined2 param_1)
+void fn_80130124(u16 param_1)
 {
+    lbl_803DE418 = param_1;
 }
 
 /*
@@ -291,6 +310,19 @@ void FUN_8013012c(undefined8 param_1,double param_2,double param_3,undefined8 pa
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8,
                  undefined4 param_9,undefined4 param_10,undefined4 param_11,undefined4 param_12,
                  undefined4 param_13,undefined4 param_14,undefined4 param_15,undefined4 param_16)
+{
+}
+
+/* EN v1.0 Address: 0x80130224  Size: 12b
+ * Signed-byte getter for lbl_803DE570. */
+s32 fn_80130224(void)
+{
+    return lbl_803DE570;
+}
+
+/* EN v1.0 Address: 0x8013023C  Size: 4b
+ * Empty function — just blr. */
+void fn_8013023C(void)
 {
 }
 
@@ -365,6 +397,12 @@ void FUN_801303fc(undefined4 param_1,undefined2 param_2)
 {
 }
 
+/* EN v1.0 Address: 0x8013045C  Size: 4b
+ * Empty function — just blr. */
+void fn_8013045C(void)
+{
+}
+
 /*
  * --INFO--
  *
@@ -426,8 +464,9 @@ void FUN_80130618(void)
  * PAL Address: TODO
  * PAL Size: TODO
  */
-void FUN_801307d4(undefined param_1)
+void fn_801307D4(u8 param_1)
 {
+    lbl_803DE578 = param_1;
 }
 
 /*
@@ -442,11 +481,9 @@ void FUN_801307d4(undefined param_1)
  * PAL Address: TODO
  * PAL Size: TODO
  */
-void FUN_801307dc(void)
-
+void fn_801307DC(void)
 {
-  DAT_803de579 = 0;
-  return;
+    lbl_803DE579 = 0;
 }
 
 /*
@@ -461,11 +498,9 @@ void FUN_801307dc(void)
  * PAL Address: TODO
  * PAL Size: TODO
  */
-void FUN_801307e8(void)
-
+void fn_801307E8(void)
 {
-  DAT_803de579 = 1;
-  return;
+    lbl_803DE579 = 1;
 }
 
 /*

--- a/src/main/dll/baddie/wall_crawler.c
+++ b/src/main/dll/baddie/wall_crawler.c
@@ -147,19 +147,37 @@ extern f32 FLOAT_803e2e60;
 extern void* PTR_DAT_8031c228;
 extern void* PTR_DAT_8031c238;
 
+/* Narrowly-typed aliases for the sbss state vars this DLL owns. */
+extern s8 lbl_803DE428;
+extern s8 lbl_803DE454;
+extern u8 lbl_803DE4C0;
+extern u8 lbl_803DE439;
+extern u8 lbl_803DE538;
+extern s16 lbl_803DE50E;
+extern s16 lbl_803DE510;
+extern s16 lbl_803DE512;
+extern s16 lbl_803DE53A;
+extern s16 lbl_803DE540;
+extern s16 lbl_803DE542;
+extern u16 lbl_803DE50C;
+
 /* Local declarations keep imported functions visible within the TU. */
 void FUN_8012ebbc(undefined8 param_1,undefined8 param_2,undefined8 param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8);
 void FUN_8012ecb8(undefined8 param_1,undefined8 param_2,undefined8 param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8);
-int FUN_8012ee7c(void);
+s32 fn_8012EE7C(void);
+void fn_8012EE88(void);
 void FUN_8012ee94(int param_1,undefined4 param_2,undefined4 param_3,int param_4);
-int FUN_8012f000(void);
+void fn_8012EF5C(void);
+s16 fn_8012EFA0(void);
+s32 fn_8012EFA8(void);
+s32 fn_8012F000(void);
 void FUN_8012f04c(undefined8 param_1,double param_2,double param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8,
                  undefined4 param_9,undefined4 param_10,undefined4 param_11,undefined4 param_12,
                  undefined4 param_13,undefined4 param_14,undefined4 param_15,undefined4 param_16);
-void FUN_8012f288(undefined2 param_1);
+void fn_8012F288(u16 param_1);
 void FUN_8012f298(undefined8 param_1,double param_2,double param_3,undefined8 param_4,
                  undefined8 param_5,undefined8 param_6,undefined8 param_7,undefined8 param_8,
                  undefined4 param_9,undefined4 param_10,uint param_11,undefined4 param_12,
@@ -211,10 +229,17 @@ void FUN_8012ecb8(undefined8 param_1,undefined8 param_2,undefined8 param_3,undef
  * PAL Address: TODO
  * PAL Size: TODO
  */
-int FUN_8012ee7c(void)
-
+s32 fn_8012EE7C(void)
 {
-  return (int)DAT_803de428;
+    return lbl_803DE428;
+}
+
+/* EN v1.0 Address: 0x8012EE88  Size: 12b
+ * Clear the signed-byte state at lbl_803DE428 (companion setter to
+ * fn_8012EE7C's getter). */
+void fn_8012EE88(void)
+{
+    lbl_803DE428 = 0;
 }
 
 /*
@@ -233,6 +258,27 @@ void FUN_8012ee94(int param_1,undefined4 param_2,undefined4 param_3,int param_4)
 {
 }
 
+/* EN v1.0 Address: 0x8012EF5C  Size: 12b
+ * Latch the u8 flag at lbl_803DE4C0 to 1. */
+void fn_8012EF5C(void)
+{
+    lbl_803DE4C0 = 1;
+}
+
+/* EN v1.0 Address: 0x8012EFA0  Size: 8b
+ * Halfword getter (signed load) at lbl_803DE53A. */
+s16 fn_8012EFA0(void)
+{
+    return lbl_803DE53A;
+}
+
+/* EN v1.0 Address: 0x8012EFA8  Size: 12b
+ * Signed byte getter at lbl_803DE454 (lbz + extsb). */
+s32 fn_8012EFA8(void)
+{
+    return lbl_803DE454;
+}
+
 /*
  * --INFO--
  *
@@ -245,11 +291,24 @@ void FUN_8012ee94(int param_1,undefined4 param_2,undefined4 param_3,int param_4)
  * PAL Address: TODO
  * PAL Size: TODO
  */
-int FUN_8012f000(void)
-
+s32 fn_8012F000(void)
 {
-  return (int)DAT_803de540;
+    return lbl_803DE540;
 }
+
+/* EN v1.0 Address: 0x8012F008  Size: 36b
+ * If arg matches lbl_803DE542, clear the byte flag at lbl_803DE538
+ * and return 1; else return 0. Classic "match and consume" helper. */
+#pragma scheduling off
+s32 fn_8012F008(s32 arg)
+{
+    if (arg == lbl_803DE542) {
+        lbl_803DE538 = 0;
+        return 1;
+    }
+    return 0;
+}
+#pragma scheduling reset
 
 /*
  * --INFO--
@@ -282,9 +341,13 @@ void FUN_8012f04c(undefined8 param_1,double param_2,double param_3,undefined8 pa
  * PAL Address: TODO
  * PAL Size: TODO
  */
-void FUN_8012f288(undefined2 param_1)
+#pragma scheduling off
+void fn_8012F288(u16 param_1)
 {
+    lbl_803DE439 = 1;
+    lbl_803DE50C = param_1;
 }
+#pragma scheduling reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
Spinoff PR from the baby_snowworm work (#13). As we started reading baby_snowworm we realised SFA has a whole family of pop-out-of-terrain baddies and input-handler-shaped DLLs in adjacent address ranges: **wall_crawler** (the big biter-type worms), **dll_DB** (Dark Basin-prefixed sibling of baby_snowworm, shares the same sbss state bank), and a set of MMP_* enemies for the volcano biome.

This PR takes the **tiny helper functions** — the 4-16-byte sbss getters/setters/clear-one-flag functions that every one of these DLLs ships — and ports them to proper C. 18 ports in total, all 100% retail match.

**wall_crawler (8/17 matching):**
- `fn_8012EE7C` — `return lbl_803DE428;` (s8 getter)
- `fn_8012EE88` — clear `lbl_803DE428` to 0
- `fn_8012EF5C` — latch `lbl_803DE4C0` to 1
- `fn_8012EFA0` — `return lbl_803DE53A;` (s16 getter)
- `fn_8012EFA8` — s32 wrapper over s8 `lbl_803DE454`
- `fn_8012F000` — `return lbl_803DE540;` (s16 getter)
- `fn_8012F008` — "match u16 and consume byte" gatekeeper
- `fn_8012F288` — set flag + halfword (needs `#pragma scheduling off`)

**dll_DB (10/30 matching):**
- `fn_8012FEE0`, `fn_80130110`, `fn_80130124`, `fn_801307D4` — 1-arg byte/halfword setters
- `fn_80130118`, `fn_801307DC`, `fn_801307E8` — constant writes (0x3C, 0, 1)
- `fn_80130224` — s8 getter
- `fn_8013023C`, `fn_8013045C` — empty functions (just `blr`)

**Techniques:**
- Narrow-typed `extern` aliases (`u8`/`s8`/`u16`/`s16`) for every sbss/sdata label these helpers touch, so MWCC emits the right `lbz/lbzx/lha/lhz/stb/sth` width directly.
- `#pragma scheduling off` on the one helper (`fn_8012F288`) where MWCC reorders `stb`/`sth`.
- For stubs not in the Ghidra import, added new C function bodies inline at the right address position in the file.

**Deliberately left as stubs:**
- 3 `extsb + stb` signed-byte setters in dll_DB (`fn_8012FEE8`, `fn_80130230`, `fn_80130380`) — MWCC drops the redundant extsb no matter how the C types the arg or cast.
- 1 three-halfword setter in wall_crawler (`fn_8012EF40`) — same class of issue, retail has `extsh` before each `sth` and MWCC skips them as redundant.

**SDK Code:** unchanged at 100.00% (1010/1010 functions).
**Game Code matched count:** from this branch's main baseline of 3, now 21 functions matching retail bytes.

This PR stacks cleanly alongside #13 (`baby-snowworm-round2`) — they touch different DLL files; the baby_snowworm stuff stays in #13 and the neighbouring baddies land here.

## Test plan
- [x] `ninja` clean build
- [x] `build/GSAE01/main.dol: OK` (sha1 check)
- [x] objdiff report: 18 functions across wall_crawler.c + dll_DB.c at 100% fuzzy match
- [x] SDK Code: 100.00% matched — no regressions