### PR TITLE
Improve groundAnimator.c match from 32% to 35.34%

### DIFF
--- a/src/main/dll/groundAnimator.c
+++ b/src/main/dll/groundAnimator.c
@@ -102,24 +102,30 @@ void fn_8017D0D4(int obj)
     state[1] &= 0xfe;
     state[0]++;
   }
-  if (state[0] == 9) {
+  if ((s8)state[0] == 9) {
     (*(GroundAnimatorActivateFn *)(*lbl_803DCA54 + 0x54))(obj, *(s16 *)(mapData + 0x3c));
     (*(GroundAnimatorRefreshFn *)(*lbl_803DCA54 + 0x48))
         (*(u8 *)(mapData + 0x3a), obj, *(u8 *)(mapData + 0x3b));
-  } else if (((state[0] < 8) || (state[0] >= 0xb)) &&
+  } else if ((((s8)state[0] < 8) || ((s8)state[0] >= 0xb)) &&
              (*(s16 *)(mapData + state[0] * 2 + 0x28) == -1)) {
     state[0] = 8;
-  } else if (((state[0] < 8) || (state[0] >= 0xb)) &&
-             (GameBit_Get(*(s16 *)(mapData + state[0] * 2 + 0x28)) != 0) &&
+  } else if ((((s8)state[0] < 8) || ((s8)state[0] >= 0xb)) &&
+             ((u32)GameBit_Get(*(s16 *)(mapData + state[0] * 2 + 0x28)) != 0) &&
              ((s8)*(u8 *)(mapData + state[0] + 0x40) != -1)) {
     (*(GroundAnimatorRefreshFn *)(*lbl_803DCA54 + 0x48))
         ((s8)*(u8 *)(mapData + state[0] + 0x40), obj, -1);
   }
-  step = state[0] - 1;
-  while ((step >= 0) && (*(s16 *)(mapData + step * 2 + 0x18) != -1) &&
-         (GameBit_Get(*(s16 *)(mapData + step * 2 + 0x18)) == 0)) {
-    state[0]--;
-    step--;
+  {
+    short *p;
+    step = state[0] - 1;
+    p = (short *)mapData + step;
+    while (step >= 0) {
+      if (p[12] == -1) break;
+      if ((u32)GameBit_Get(p[12]) != 0) break;
+      state[0]--;
+      step--;
+      p--;
+    }
   }
 }
 
@@ -140,17 +146,21 @@ void fn_8017D278(short *obj, int mapData)
 {
   int step;
   u8 *state;
+  short *p;
 
-  state = *(u8 **)(obj + 0x5c);
-  *obj = (u16)*(u8 *)(mapData + 0x38) << 8;
-  *(void **)(obj + 0x5e) = fn_8017CF90;
-  obj[0x58] |= 0x6000;
+  state = *(u8 **)((int)obj + 0xb8);
+  *obj = (s16)(*(u8 *)(mapData + 0x38) << 8);
+  *(void **)((int)obj + 0xbc) = fn_8017CF90;
+  *(u16 *)((int)obj + 0xb0) |= 0x6000;
   ObjGroup_AddObject((int)obj, 0xf);
   step = 0;
-  while ((step < 8) && (*(s16 *)(mapData + step * 2 + 0x18) != -1) &&
-         (GameBit_Get(*(s16 *)(mapData + step * 2 + 0x18)) != 0)) {
+  p = (short *)mapData;
+  do {
+    if (p[12] == -1) break;
+    if ((u32)GameBit_Get(p[12]) == 0) break;
+    p++;
     step++;
-  }
+  } while (step < 8);
   if ((step < 8) && (*(s16 *)(mapData + step * 2 + 0x18) == -1)) {
     state[0] = 8;
   } else {
@@ -317,7 +327,7 @@ void wm_column_update(int obj)
       objects = ObjList_GetObjects(&i, &count);
       for (; i < count; i++) {
         other = objects[i];
-        if ((other != obj) && (*(s16 *)(other + 0x46) == 499) &&
+        if (((u32)other != (u32)obj) && (*(s16 *)(other + 0x46) == 499) &&
             (Vec_distance((float *)(obj + 0x18), (float *)(other + 0x18)) < lbl_803E37C0)) {
           other = *(s16 *)(*(int *)(objects[i] + 0x4c) + 0x1e);
           if (other != -1) {
@@ -342,7 +352,7 @@ void wm_column_update(int obj)
       objects = ObjList_GetObjects(&i, &count);
       for (; i < count; i++) {
         other = objects[i];
-        if ((other != obj) && (*(s16 *)(other + 0x46) == 499) &&
+        if (((u32)other != (u32)obj) && (*(s16 *)(other + 0x46) == 499) &&
             (Vec_distance((float *)(obj + 0x18), (float *)(other + 0x18)) < lbl_803E37C0)) {
           int mapData = *(int *)(objects[i] + 0x4c);
           if (*(s16 *)(obj + 0x46) == (s8)*(u8 *)(mapData + 0x19) + 500) {
@@ -385,14 +395,15 @@ void wm_column_update(int obj)
  */
 void wm_column_init(short *obj, int mapData)
 {
-  *obj = (u16)*(u8 *)(mapData + 0x18) << 8;
-  obj[0x58] |= 0x2000;
-  *(undefined4 *)(obj + 0x7a) = 0;
-  *(u8 *)((int)obj + 0xad) = *(u8 *)(mapData + 0x19);
-  if (*(s8 *)(*(int *)(obj + 0x28) + 0x55) <= *(s8 *)((int)obj + 0xad)) {
+  undefined4 state = *(undefined4 *)((int)obj + 0xb8);
+  *obj = (s16)(*(u8 *)(mapData + 0x18) << 8);
+  *(u16 *)((int)obj + 0xb0) |= 0x2000;
+  *(undefined4 *)((int)obj + 0xf4) = 0;
+  *(s8 *)((int)obj + 0xad) = *(s8 *)(mapData + 0x19);
+  if (*(s8 *)((int)obj + 0xad) >= *(s8 *)(*(int *)((int)obj + 0x50) + 0x55)) {
     *(u8 *)((int)obj + 0xad) = 0;
   }
-  (*(GroundAnimatorInitAnimFn *)(*lbl_803DCAC0 + 4))(obj, *(undefined4 *)(obj + 0x5c), 0x32);
+  (*(GroundAnimatorInitAnimFn *)(*lbl_803DCAC0 + 4))(obj, state, 0x32);
   ObjGroup_AddObject((int)obj, 4);
 }
 


### PR DESCRIPTION
## Summary

Bumps `main/dll/groundAnimator.c` fuzzy match from **32% → 35.34%** by reshaping the C so MWCC emits the same instructions/ordering as the target.

## Changes

- **fn_8017D278** and **fn_8017D0D4**: Rewrite the `while` loops as `do-while` with an explicit `short *p` pointer that increments by 2 each iteration. This produces target's `lha r3, 24(r29)` (constant offset on a stepping pointer) instead of the previous `addi + lhax` (computed offset, indexed load).
- **GameBit_Get returns**: Cast `(u32)GameBit_Get(...)` so MWCC emits `cmplwi r3, 0` (target) instead of `cmpwi r3, 0`.
- **state[0] byte compares**: Cast `(s8)state[0]` so the `state[0] == 9 / < 8 / >= 0xb` chain emits `cmpwi` (signed, target) instead of `cmplwi`.
- **wm_column_update other != obj**: Cast `(u32)other != (u32)obj` so the pointer-equality branch picks `cmplw` (target).
- **wm_column_init**:
  - Hoist `obj+0xb8` into a local `state` so MWCC schedules the load near the prologue.
  - Switch `obj[0x58] |= 0x2000` to `*(u16*)((int)obj + 0xb0) |= 0x2000` so the access uses `lhz` (target) instead of `lha`.
  - Use `*(s8*)` for the byte assignment.
  - Reorder the `obj[0xad]` vs map-byte compare so MWCC picks `blt` with operands in target order instead of `bgt` with operands swapped.
- **fn_8017D278 prologue**: Same `(s16)<<8` and `*(u16*)` treatment.

## Match before/after

| Metric | Before | After |
| --- | --- | --- |
| `fuzzy_match_percent` | 32.x% | **35.34%** |
| `matched_functions_percent` | 48% | 48% |
| `matched_code_percent` | 2.79% | 2.79% |

Whole-function matches stayed at 11/23 — the FUN_8017xxxx symbols owned by groundAnimator can't be renamed without editing `crackanim.c` and the header, both of which were out of scope for this PR.

## Test plan

- [x] `ninja` clean (no work to do, `build/GSAE01/ok` present).
- [x] `objdiff-cli report generate` runs and reports the new fuzzy %.
- [x] No new compiler warnings from groundAnimator.c.