### PR TITLE
fn_801B3DE4 (dimexplosion): 100% match — defeat the front-end same-va…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,16 @@ actionable trigger→fix; **full detail, examples, negative-maps, and frontier a
 - **A config that DROPS the headline % but introduces a needed STRUCTURAL feature (extra saved
   reg, surviving `mr`/`fmr` copy, an un-coalesced web) is worth a FULL per-region diff before
   rejecting — don't bail on the number alone.** Reject ONLY when the residual is provably
-  config-INHERENT and not merely larger. Worked example: fn_801B3DE4 (dimexplosion) —
-  `#pragma optimization_level 1` yields the target's 6th saved reg (`_savegpr_26`) + the `mr
-  r29,r31` base copy that O4 value-numbering folds away, but caps BELOW O4's 97.07% because the
-  +34 instrs are O1-inherent (per-conversion `lis 17200`, expf-chain f1/f2 coloring) — a real
-  trade-down, confirmed only by reading every region. Contrast: O1/O2 creation-order alloc (#108)
-  and O1≈O4 small-loop fns (#110) ARE genuine climbs — measure, don't assume.
+  config-INHERENT and not merely larger. Worked example: fn_801B3DE4 (dimexplosion) — `#pragma
+  optimization_level 1` yields the target's 6th saved reg + the `mr r29,r31` base copy that O4
+  value-numbering folds away, but at +34 O1-inherent instrs (per-conversion `lis 17200`, expf
+  coloring). For a long time this read as a config-inherent trade-down → "bank it." **That verdict
+  was WRONG: the `mr` copy was reachable at O4 from a SOURCE lever (#131 — a no-op `|=` defeats the
+  front-end same-value merge), and the fn is now 100%.** Lesson: a pragma that surfaces a needed
+  structural feature only tells you the feature is REACHABLE — keep hunting a source form that
+  produces it WITHOUT the pragma's collateral cost; "config-inherent residual" is a hypothesis,
+  not a verdict. Contrast: O1/O2 creation-order alloc (#108) and O1≈O4 small-loop fns (#110) ARE
+  genuine climbs — measure, don't assume.
 
 ## High-impact one-liners (try first at 80-95%)
 1. **`#pragma peephole off` + `scheduling off`** (matched with `reset`) around the fn — unfuses
@@ -325,10 +329,12 @@ actionable trigger→fix; **full detail, examples, negative-maps, and frontier a
     flags → very bottom. Use-count/first-use/loop-depth are INERT within a class. CLASS-MOVERS
     (the lever): first-def-split (a branch-consumed call result → its own var), last-def merge,
     `#pragma optimization_level 2` (creation-order alloc), block-scope per-arm re-decls, same-
-    variable recycle (#119). WITHIN-class order is the genuine open frontier (rotmap first; the
-    transposition penalty drowns real structural fixes — fix those, then bank the pure-rename
-    residual). Cross-class interleave is perturbed fn-globally by a magic-const division /
-    conversions (dose effect) — characterized, source-levers exhausted; bank-and-retry.
+    variable recycle (#119), and #131 (no-op `|=` to force a surviving same-value copy + own web —
+    the source for an "un-coalesced web" the allocator otherwise folds). WITHIN-class order is the
+    smallest residual (rotmap first; the transposition penalty drowns real structural fixes — fix
+    those first). "Source-levers exhausted / bank-and-retry" has been WRONG repeatedly (#130, #131):
+    treat it as not-yet-found, not impossible. Cross-class interleave is perturbed fn-globally by a
+    magic-const division / conversions (dose effect).
 109. **s64/fixed-point cracks:** (a) `x <<= (n & 0xFFFFFFFF)` materializes the shift-count mask; (b)
     count-down `for(i=N;i!=0;i--)` for the RMW-halving unroll (fixed regs + per-copy `mr`); (c) two-
     web u32 address temp; (d) plain-statement `cmp; beq next; b far` = a single-case `switch` with
@@ -421,13 +427,38 @@ actionable trigger→fix; **full detail, examples, negative-maps, and frontier a
     changes the interference graph, and flips the allocator's reg choice with ZERO other instruction
     change — reuses a different just-freed reg. CONVERSE (un-name a temp by inlining its defining
     EXPRESSION at each use, #107) also flips it. ONLY works for re-derivable values (memory derefs,
-    `obj->field`); does NOT work for CALL RESULTS (can't re-call) or VN-equal pointer copies (fold
-    back). Also #115-adjacent: renaming ONE loop's counter to a distinct var removes a cross-loop
+    `obj->field`); does NOT work for CALL RESULTS (can't re-call). VN-equal pointer copies were
+    thought to fold back here too — #131's no-op `|=` cracks THOSE (forces a surviving copy + own
+    web). Also #115-adjacent: renaming ONE loop's counter to a distinct var removes a cross-loop
     coalescing barrier. Brute-force MANY spellings and grep the affected reg each build — this
     cracked dim2roofrub_update (byte-identical-except-r29/r31, declared an uncrackable cap by 5
     prior agents → 100%) and the int-permutation half of dimwooddoor (pitchSign from fresh
     modelVec[1] read). The "#108 within-class scramble is the genuine open frontier / no source
-    lever" assertion is FALSE for deref-sourced values — second-guess it.
+    lever" assertion is FALSE for deref-sourced values — second-guess it. **Now also FALSE for
+    VN-equal pointer copies — see #131 (the no-op-bitwise merge-defeat). The "open frontier" is
+    much smaller than it looks; assume a source lever exists and hunt the asm.**
+131. **The front-end SAME-VALUE MERGE is breakable: a no-op bitwise op forces a surviving `mr`
+    copy + a SEPARATE web (the clean-C source for "two overlapping same-value saved regs joined by
+    a copy" — what #108/#130 called the open frontier).** Two identical `state+off` (one base for
+    most fields, a second for ONE field) get value-numbered into ONE web by the FRONT-END *before
+    any optimizer pass* — proven by ret-patching IroCSE/IroPropagate/IroRangeProp/AddProp/VN, all
+    survive; every `opt_*`/pragma/opt-level/compiler-version (1.0–3.0a5) folds it; a plain second
+    pointer, `e14=e` copy, cast, phi-with-overhead, or opaque call-result all fold or add cost.
+    DEFEAT IT: `e14 = state + off; e14 |= e;` (e == state+off) → emits `or r29,r31,r31` (== `mr
+    r29,r31`) AND keeps e14 a distinct web, because the `|` node blocks the merge — value still
+    state+off, ZERO extra instructions, no branch. Then (a) pin the reg with #108 DECL-ORDER
+    (declare e14 FIRST → r29); (b) align the copy's POSITION by computing the field value to a temp
+    first (`int life = (int)(K*sqrtf(spd)); e14 = state+off; e14 |= e; *(int*)(e14+0x14)=life;`) so
+    the def/`mr` sits AFTER the intervening call, matching target. `&=`/`|=` both work (no-op when
+    the operand equals the lvalue). Companion (#112 corollary, same fn): the per-call slot re-derive
+    + add operand order — grouping the field K onto the BASE (`(char*)((char*)state + K) + idx*0x30`)
+    re-derives `state+off` per call AND emits `add r28,r30` (state,off order); grouping K onto the
+    INDEX (`state + (idx*0x30 + K)`) re-derives but FLIPS to `add r30,r28` (off,state) — the last
+    3-byte gap. METHOD: this fell ONLY after switching from fail-fast-on-fuzzy% to a structural-
+    distance metric (count real instr/reg diffs vs target asm, ignore @NNN-reloc names + subi/addi
+    display) — a 96% variant was structurally CLOSER than the 98% baseline; the % hid the path.
+    Read the emitted asm per variant. (fn_801B3DE4/dimexplosion: flagged impossible/"open frontier"
+    across ~15 sessions → 100%.)
 
 ## Reference tables & misc levers
 - **Caller-side width controls extsb/extsh:** extension on the PARAM side → widen param to `int`,

--- a/docs/mwcc_re/HANDOVER_x86_ubuntu.md
+++ b/docs/mwcc_re/HANDOVER_x86_ubuntu.md
@@ -1,5 +1,19 @@
 # Handover: crack fn_801B3DE4 via dynamic RE of mwcceppc (x86 Ubuntu)
 
+> **✅ SOLVED 2026-06-21 — fn_801B3DE4 is 100% byte-matched from clean C (no asm, no dynamic-RE
+> needed in the end). Solution + recipe in `fn_801B3DE4_SOLVED.md` and CLAUDE.md #131. The dynamic-RE
+> tooling below (gdb-at-guest-VA, patched-compiler diagnostics) remains valid and reusable for the
+> next hard residual, but this function is done — don't re-attack it.**
+>
+> **UPDATE 2026-06-20 (x86_64 Ubuntu session):** Dynamic RE is now OPERATIONAL. gdb breaks at
+> guest VAs under wibo; setup in `gdb_setup.sh`, repro TU in `fn_801B3DE4_mini.c`, pass profile
+> + REFINED diagnosis in `fn_801B3DE4_partial.md`. Headline correction: the divergence is
+> **local CSE** of two identical pure `state+off` exprs in the entry BB (robust across O0–O4 and
+> every relevant pragma), NOT an unconditional VN fold, and NOT reproducible from clean C
+> without rescrambling the #36/#77 whole-TU coloring. Still banked at 98.04%. Read the partial
+> doc before re-attacking. Open next step: instrument IroCSE/VN to learn why the retail compile
+> turned the 2nd state+off into a surviving COPY rather than substituting it away.
+
 You are continuing work that was blocked on an arm64 Mac. **Goal: 100% match
 `fn_801B3DE4` using the compiler reverse-engineering technique** (no inline asm — forbidden).
 On x86 Ubuntu the path that was blocked for me — live-debugging the compiler — is open to you.

--- a/docs/mwcc_re/fn_801B3DE4_SOLVED.md
+++ b/docs/mwcc_re/fn_801B3DE4_SOLVED.md
@@ -1,0 +1,44 @@
+# fn_801B3DE4 (dll_01CA_dimexplosion) — SOLVED, 100% (2026-06-21)
+
+Supersedes fn_801B3DE4_partial.md (which concluded "banked at 98.04%, impossible").
+It was NOT impossible. Two clean-C levers, found by reading the asm + measuring
+*structural distance* (not just fuzzy %), close it byte-for-byte.
+
+## The two divergences and their fixes
+
+### A — `mr r29,r31`: the 0x14/lifetime base needs its own saved reg
+The target keeps `state+off` in TWO overlapping saved regs (r31=e for all fields,
+r29=e14 for 0x14 only), joined by a surviving `mr` copy. The front-end value-numbers
+two identical `state+off` into one web, so a plain second pointer folds. Defeat the
+merge with a no-op bitwise op whose value is still `state+off`:
+
+    int e14;                          /* DECLARE FIRST -> lands in r29 */
+    ...
+    int life = (int)(K * sqrtf(spd)); /* compute lifetime to a temp first... */
+    e14 = state + off;
+    e14 |= e;                         /* ...|= e (==state+off): mr r29,r31 + separate web, no branch */
+    *(int*)((char*)e14 + 0x14) = life;/* placed AFTER sqrtf -> mr at the right position */
+
+`e14 |= e` emits `or r29,r31,r31` (== `mr r29,r31`) and keeps e14 a distinct web
+because the `|` node blocks the value-number merge. Declaring e14 first pins it to r29;
+doing this after the sqrtf temp aligns the mr to the target's position.
+
+### B — random section: per-call re-derive of the slot base, `add state,off` order
+Target recomputes the 0x28/0x2c slot address fresh into volatile r3 after each
+`randomGetRange` call (calls clobber r3), and uses r27 for the multi-use 0x2a base.
+Mine hoisted one base into saved r27. Fix = recipe #112 K-grouping, grouping the field
+offset onto the *base pointer* (not the index):
+
+    *(s16*)((char*)((char*)state + 0x28) + idx * 0x30) = randomGetRange(...);
+
+`((char*)state + K) + idx*0x30` makes each store's base value-number distinct (different
+K) -> no CSE -> re-derives per call; and because K is grouped onto `state`, the displacement
+folds into the store and the add is emitted `add r3,r28,r30` (state,off order) — matching.
+NOTE: grouping K onto the *index* (`state + (idx*0x30 + K)`) also re-derives but flips the
+add to off,state order (`add r3,r30,r28`) — that was the last 3-byte gap (99.83 -> 100).
+
+## Method note
+The breakthrough came from a structural-distance metric (`tools`-style /tmp/rd.py: count real
+instruction/reg diffs vs target, ignoring score-neutral @NNN reloc names and subi/addi display).
+It exposed that a 96% variant could be *structurally closer* than the 98% baseline — fuzzy %
+alone hid the path. Always read the emitted asm per variant; don't fail-fast on the headline %.

--- a/docs/mwcc_re/fn_801B3DE4_mini.c
+++ b/docs/mwcc_re/fn_801B3DE4_mini.c
@@ -1,0 +1,79 @@
+typedef unsigned char u8;
+typedef signed char s8;
+typedef short s16;
+typedef unsigned int u32;
+typedef float f32;
+
+extern f32 lbl_803E492C, lbl_803E4930, lbl_803E4934, lbl_803E4938, lbl_803E493C, lbl_803E4940;
+extern f32 gExplosionDebrisAlphaScale, gExplosionDebrisSpeedScale;
+extern f32 sqrtf(f32);
+extern f32 expf(f32);
+extern int randomGetRange(int, int);
+extern void Sfx_PlayFromObject(int, int);
+extern void Sfx_PlayFromObjectLimited(int, int, int);
+
+void fn_801B3DE4(int obj, u8 b, f32 spd, f32 x, f32 y, f32 z)
+{
+    int p4c = *(int*)(obj + 0x4c);
+    int state = *(int*)(obj + 0xb8);
+    int idx;
+    int off;
+    int e;
+    int e14;
+    char* p;
+    idx = (*(u8*)(state + 0xa58))++;
+    off = idx * 0x30;
+    *(f32*)((char*)state + off) = x;
+    e = state + off;
+    *(f32*)((char*)e + 0x4) = y;
+    *(f32*)((char*)e + 0x8) = z;
+    *(f32*)((char*)e + 0x18) = lbl_803E492C;
+    *(f32*)((char*)e + 0xc) = *(f32*)((char*)state + 0x18);
+    *(f32*)((char*)e + 0x1c) = spd;
+    *(u8*)((char*)e + 0x2d) = b;
+    *(int*)((char*)e + 0x10) = 0;
+    e14 = state + off;
+    *(int*)((char*)e14 + 0x14) = (int)(lbl_803E4930 * sqrtf(spd));
+    {
+        int v = *(int*)((char*)e14 + 0x14);
+        if (v < 0) { v = 0; }
+        else if (v > 0x3c) { v = 0x3c; }
+        *(int*)((char*)e14 + 0x14) = v;
+    }
+    if (*(u8*)((char*)e + 0x2d) < 1)
+    {
+        s8 c = *(s8*)((char*)p4c + 0x19);
+        if (c != 0)
+        {
+            if (c == 2) { Sfx_PlayFromObject(obj, 0x4bf); }
+            else if (c == 3) { Sfx_PlayFromObject(obj, 0x4c2); }
+            else
+            {
+                s8 m = *(s8*)(obj + 0xac);
+                if (m < 0x3a) { if (m == 0x2c) { goto playLimited; } }
+                else if (m < 0x3f) { playLimited: Sfx_PlayFromObjectLimited(obj, 0x4b8, 2); goto done; }
+                Sfx_PlayFromObject(obj, 0x203);
+            done:;
+            }
+        }
+    }
+    *(s16*)((char*)state + idx * 0x30 + 0x28) = randomGetRange(0, 0xffff);
+    *(s16*)((char*)state + idx * 0x30 + 0x2a) = randomGetRange(0xc8, 0x12c);
+    if ((int)randomGetRange(0, 1) != 0)
+        *(s16*)((char*)state + idx * 0x30 + 0x2a) = -*(s16*)((char*)state + idx * 0x30 + 0x2a);
+    *(u8*)((char*)state + idx * 0x30 + 0x2c) = randomGetRange(0, 3);
+    {
+        f32 sp = *(f32*)((char*)e + 0x1c);
+        f32 ev = expf((lbl_803E4934 * ((f32)(int) * (int*)((char*)e14 + 0x14) - (f32)(int) * (int*)((char*)e + 0x10))) / (f32)(int) * (int*)((char*)e14 + 0x14));
+        f32 d = sp - *(f32*)((char*)e + 0x18);
+        f32 t = d * ev;
+        *(f32*)((char*)e + 0xc) = sp - gExplosionDebrisSpeedScale * t;
+        ev = expf((lbl_803E493C * (f32)(int) * (int*)((char*)e + 0x10)) / (f32)(e = (int) * (int*)((char*)e14 + 0x14)));
+        t = lbl_803E4938 * ev;
+        p = (char*)state;
+        *(s8*)(p + idx * 0x30 + 0x2e) = lbl_803E4938 - gExplosionDebrisAlphaScale * t;
+        *(int*)(p + idx * 0x30 + 0x20) = lbl_803E4940;
+        *(int*)(p + idx * 0x30 + 0x24) = *(int*)(p + idx * 0x30 + 0x20);
+        *(u8*)(p + idx * 0x30 + 0x2f) = 1;
+    }
+}

--- a/docs/mwcc_re/fn_801B3DE4_partial.md
+++ b/docs/mwcc_re/fn_801B3DE4_partial.md
@@ -1,5 +1,11 @@
 # fn_801B3DE4 (dll_01CA_dimexplosion) — documented partial @ 98.04%
 
+> **✅ SOLVED 2026-06-21 — 100% byte-match. See `fn_801B3DE4_SOLVED.md` and CLAUDE.md recipe #131.**
+> The "impossible / open-frontier / requires inline asm" conclusion below was WRONG: two clean-C
+> levers close it — a no-op `e14 |= e` to defeat the front-end same-value merge (→ `mr r29,r31`),
+> and #112 K-grouping onto the base for the random section. Kept below only as a record of the
+> (long, repeatedly-mistaken) negative path. Do not re-attack — it's matched.
+
 Per the prime directive: residual that won't yield → commit the partial, document the
 target-vs-ours asm shape, keep on the retry list.
 
@@ -42,14 +48,108 @@ example: "the `mr r29,r31` base copy that O4 value-numbering folds away."
 7. `e14 = state + idx*0x30`                       + decl-order/hoist brute battery
 None produced `mr r29,r31`. Confirmed by objdump grep on the rebuilt `.o` each time.
 
-## Why dynamic instrumentation didn't help (on this host)
-arm64 Mac: `mwcceppc.exe` (32-bit PE) runs under wibo via i386 LDT code segments under
-Rosetta 2. lldb breakpoints at the PE's VAs (`0x509010`) don't hit — the guest code is
-mapped at an unknown high host address through a segment, not at its flat VA. Reaching it
-needs RE of wibo's guest-memory model, or a Linux x86 host where gdb can break at the VA.
+## Dynamic instrumentation — NOW OPERATIONAL (x86_64 Ubuntu, 2026-06-20)
+The Mac block is gone. On native x86_64 Linux, wibo maps the PE at image base 0x400000 and
+runs the guest in compatibility mode; a software breakpoint at a guest VA (`0x509010`) hits
+and gdb reads regs normally. Setup (no sudo): `docs/mwcc_re/gdb_setup.sh` (fetches gdb +
+libs as .debs into /tmp). Break at wibo's `call_EntryProc` first (maps the PE), then set the
+guest-VA breakpoint. Standalone repro TU: `docs/mwcc_re/fn_801B3DE4_mini.c` (raw-offset
+field accesses; reproduces the FOLD but not the whole-TU coloring).
+
+Pass-entry profile for ONE compile of fn_801B3DE4 (from the mini TU under gdb):
+`ValueNumbering` (0x509010) **96x**, `IroPropagate` 9x, `IroCSE` 2x, `Coloring` 1–2x each.
+
+## REFINED DIAGNOSIS (supersedes the "VN folds unconditionally" framing above)
+The handover blamed value-numbering, but the target emits `mr r29,r31` — a **copy of r31**,
+not an `add r28,r30` recompute — so VN/codegen DID prove e14==e. The real shape is:
+- The two `state + off` computations (e at line 186, e14 at line 194) sit in the SAME entry
+  basic block, separated only by stores and the sqrtf call (calls don't split BBs, and
+  state+off is pure arithmetic a call can't kill). **LOCAL CSE merges them unconditionally.**
+- Proven robust: the fold to a single register survives `optimization_level 0/1/2/3/4` AND
+  `peephole off` AND `opt_propagation off` AND `opt_common_subs off` (the latter only
+  disables *global* CSE; local in-BB CSE still folds — verified: with all three off, one
+  `add r28,r29,r5` feeds every field incl. 0x14). O1 gives `_savegpr_26` (6th saved reg) but
+  STILL no separate e14 / no `mr` — the CLAUDE.md worked-example claim that "O1 yields the
+  `mr r29,r31`" is INACCURATE (checked in both mini and in-tree).
+- The target's copy is materialized AFTER sqrtf, i.e. the original computed the 0x14 base
+  inline in the store statement. Reproducing that position (T1: inline `(state+off)` at each
+  0x14 use; T2: `int life = (int)(K*sqrtf(spd)); e14 = state+off;` after the call) folds
+  identically — position-independent, as expected for a pure expr in one BB.
+- Best theory for the target's surviving copy: in the retail compile CSE turned the 2nd
+  state+off into a COPY (not a substitution) that reached the **conservative coalescer**
+  (Coloring.c 0x508c10), which refused to merge r29 into r31 under that TU's register
+  pressure. In our builds CSE *substitutes* (eliminates e14 before coalescing), so no copy
+  ever reaches the coalescer. Why CSE copies-vs-substitutes here is the open question for the
+  next dynamic session (break in IroCSE 0x46a360 / VN 0x509010 and watch state+off's 2nd
+  occurrence).
+
+## Source levers tried (this session, on top of the 13 above) — all fold or regress
+`e14=e` (97.32, VN-merges to one web, allocator scrambles to r28); `(int)((long)state+off)`
+and `state+(int)(long)off` (97.32, splits the web but parks e14 in r28, no copy, worse);
+`(int)((long)(state+off))` / `(int)((char*)state+off)` (fold/regress); inline-T1, post-call-T2
+(98.04 unchanged); address-taken `&e14` (93.85, spills). The #36/#77 whole-TU coloring
+coupling is the real wall: any VN-split that separates e14 rescrambles the function's 5-reg
+coloring instead of cleanly ADDING a 6th (r29) + copy.
 
 ## Verdict / retry list
-100% requires the `mr r29,r31` copy, which O4 value-numbering folds unconditionally for
-this expression. No clean-C lever found; inline asm is forbidden. Banked at 98.04%.
-Next genuine attempts: (a) static RE of `ValueNumbering.c` @ 0x509010 to find the exact
-non-fold condition; (b) Linux-host dynamic instrumentation of the same address.
+Banked at 98.04% (single missing `mr r29,r31`). No clean-C lever at any opt level / pragma
+combination reproduces it; inline asm forbidden. The fold is local-CSE-driven and robust; the
+target's copy is a coalescer artifact of the full-TU register pressure, not source-reachable
+without perturbing the documented #36/#77 coloring coupling. Dynamic RE is now operational —
+the precise next attempt is to instrument IroCSE/VN and find why CSE inserts a copy (not a
+substitution) for the 2nd state+off, then engineer a source construct that triggers the
+copy-insertion path while leaving the other 5 saved-reg webs intact.
+
+## DEEP RE — CONCLUSIVE ROOT CAUSE (2026-06-20, x86_64 session 2)
+After exhausting source levers, the deep allocator RE settled the mechanism definitively.
+The earlier "local CSE" framing was incomplete — the true root cause:
+
+**The divergence is a register-allocator outcome: the target holds `state+off` in TWO
+overlapping saved regs (r31 AND r29 are both live and equal in the falloff), joined by a
+`mr` copy that SURVIVES coalescing. Our compiler never produces two overlapping same-value
+ranges — it always keeps one register.** Evidence (all via the gdb/patched-compiler harness):
+
+- **It is NOT a CSE pass.** Binary-patched the compiler to ret-disable IroCSE (0x46a360),
+  IroPropagate (0x470060), IroRangeProp (0x49ea50), AddPropagation (0x56ba20), ValueNumbering
+  (0x509010), and NOP'd the VN operand-substitution at 0x509098. The single-register fold
+  SURVIVES ALL of them → the two `state+off` are merged by the FRONT-END value-numberer
+  before any optimizer runs. Cannot create two source webs.
+- **Same-value copies always coalesce.** `e14 = e` + register pressure (N=0..8 extra live
+  GPRs) → the copy is ALWAYS coalesced away (any-saved-mr=0). MWCC correctly merges a copy
+  whose src/dst hold the same value regardless of degree (no true interference). So the
+  target's surviving same-value copy contradicts our compiler's coalescer on every input.
+- **Opaque base doesn't help.** `e14 = identBase(state+off)` (call result, VN-opaque) still
+  folds 0x14 into r31 — no overlap. The corpus splits that DO survive (HuPrcChildCreate's
+  r29/r30) come from a CALL-RESULT pointer flowing through INLINED calls, or a LOOP-diverging
+  walk (explosion_render `p=state; p+=0x30`). fn_801B3DE4 is a straight-line COMPUTED base —
+  the one shape that yields the overlap, and it appears in ZERO of ~1750 functions across
+  SFA/MP4/pikmin2/prime/tww/mkdd/melee.
+- **Not a compiler version.** All of GC 1.2.5,1.2.5n,1.3,1.3.2,1.3.2r,2.0,2.0p1,2.5,2.6,2.7
+  fold (none split). NOTE: siblings in this very unit (explosion_update etc.) are 100% with
+  GC/2.0, so the compiler is correct and the match IS reachable in principle — we just can't
+  find the source shape, and the front-end merge blocks constructing it.
+
+**Verdict:** genuine #108 open-frontier residual. Banked at 98.04%. The only remaining lever
+would be external knowledge of the original source structure (macro expansion? a specific
+helper signature?) that happened to defeat the front-end's same-value merge. RE harness,
+patched-compiler diagnostics, and the 7-game corpus scanner are preserved under /tmp + this dir.
+
+## PHI BREAKTHROUGH + the closed obstacle (session 2 cont.)
+Found the ONE construct that defeats the front-end same-value merge and produces a surviving
+`mr` copy + a separate single-reg web for 0x14 (the target's exact shape):
+  `e14 = state + off; if (b == 0xab) { e14 = 0; }`  → emits `mr r27,r31`, 0x14 via r27.
+This PROVES the structure is reproducible. BUT every realization needs a phi (two reaching
+defs is the only way the front-end won't merge two equal webs), and the phi's branch +
+alternate-value are irremovable overhead the target lacks:
+- Foldable-false conditions (`if(0)`, `if(1==2)`, sizeof) are eliminated BEFORE phi creation → no split.
+- Non-foldable conditions keep the branch (cmpwi+b+li), netting 182–184 instrs / 91–96% (worse
+  than the 178-instr/98.04% baseline). opt_dead_code/opt_dead_assignments don't remove it.
+- Tying the 2nd def to an existing branch + a live value (`if(rand)…{ e14=obj; }`) reaches 180
+  instrs but 96.8% — because it puts a WRONG value (obj) on one path; the target uses state+off
+  on ALL paths.
+**Closed obstacle:** the target's branch-free `mr` between two *known-equal single-def* webs is a
+contradiction for our compiler — a register copy means the value is known equal, and known-equal
+is exactly why the front-end/coalescer merges it. Only a phi (genuinely-maybe-different) escapes
+the merge, and a phi costs a branch the target doesn't have. So 100% is not expressible in clean C
+with our mwcceppc build; it requires either the original's (unknown) source shape that happened to
+land a phi-web with zero net overhead, or a front-end/coalescer nuance in Rare's exact build.

--- a/docs/mwcc_re/gdb_setup.sh
+++ b/docs/mwcc_re/gdb_setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Reproducible dynamic-RE setup for mwcceppc.exe on x86_64 Ubuntu (no sudo required).
+#
+# The handover (HANDOVER_x86_ubuntu.md) was blocked on arm64 Mac because lldb could not
+# break at the PE's flat VAs (Rosetta + wibo segment model). On NATIVE x86_64 Linux this
+# works: wibo (an x86_64 ELF, loaded at 0x70000000+) maps the 32-bit PE at its image base
+# 0x400000 and runs the guest in compatibility mode. A software breakpoint at a guest VA
+# (e.g. 0x509010) hits normally; ptrace/gdb read the regs from the 64-bit user_regs_struct.
+#
+# This host had no gdb/sudo, so we fetch gdb + its libs as .debs and run from a local prefix.
+
+set -e
+PREFIX=/tmp/gdbpkg
+mkdir -p "$PREFIX" && cd "$PREFIX"
+for pkg in gdb libbabeltrace1 libipt2 libsource-highlight4t64 libdebuginfod1t64; do
+  [ -e "$pkg"*.deb ] || apt-get download "$pkg"
+done
+for d in *.deb; do dpkg -x "$d" gdbroot; done
+cat > /tmp/gdbrun.sh <<'EOF'
+#!/bin/bash
+export LD_LIBRARY_PATH=/tmp/gdbpkg/gdbroot/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+exec /tmp/gdbpkg/gdbroot/usr/bin/gdb "$@"
+EOF
+chmod +x /tmp/gdbrun.sh
+echo "gdb ready: /tmp/gdbrun.sh"
+
+# --- How to break at a guest VA -------------------------------------------------------
+# gdb can't insert a guest-VA breakpoint at launch (PE not mapped yet). Break first at
+# wibo's 64->32 mode-switch thunk `call_EntryProc`, THEN set the guest breakpoint:
+#
+#   break call_EntryProc      # PE is mapped once this hits
+#   run
+#   delete
+#   break *0x509010           # ValueNumbering.c entry (guest VA)
+#   continue
+#
+# Optimizer pass entry VAs (image base 0x400000), from assert_map_GC2.0.txt:
+#   IroCSE.c            0x0046a360
+#   IroPropagate.c      0x00470060
+#   Coloring.c          0x00508680 0x00508900 0x00508c10
+#   ValueNumbering.c    0x00509010   (runs ~96x per function — per-IR-node VN)
+#   InterferenceGraph.c 0x0057b680 0x0057bad0
+#
+# Run mwcceppc DIRECTLY under wibo (sjiswrap is unnecessary unless the .c carries SJIS;
+# dll_01CA_dimexplosion.c does not):
+#   /tmp/gdbrun.sh -batch -x cmds.gdb --args build/tools/wibo \
+#     build/compilers/GC/2.0/mwcceppc.exe <flags> -c <src.c> -o <outdir>/
+# Get <flags> from: ninja -t commands <unit.o>  (drop the leading sjiswrap.exe arg).
+#
+# Isolation: the full TU compiles hundreds of functions, so 0x509010 fires thousands of
+# times. To study ONE function's codegen, compile a standalone TU (see mini.c approach in
+# the partial doc) — it reproduces the *fold* but NOT the exact whole-TU coloring.

--- a/src/main/dll/DIM/dll_01CA_dimexplosion.c
+++ b/src/main/dll/DIM/dll_01CA_dimexplosion.c
@@ -173,12 +173,12 @@ typedef int (*HitDetectFloatsFirst)(int obj, f32 x, f32 y, f32 z, int out, int p
 #pragma opt_propagation off
 void fn_801B3DE4(int obj, u8 b, f32 spd, f32 x, f32 y, f32 z)
 {
+    int e14;
     int p4c = *(int*)&((GameObject*)obj)->anim.placementData;
     int state = *(int*)&((GameObject*)obj)->extra;
     int idx;
     int off;
     int e;
-    int e14;
     char* p;
     idx = ((ExplosionState*)state)->flameCount++;
     off = idx * 0x30;
@@ -191,8 +191,12 @@ void fn_801B3DE4(int obj, u8 b, f32 spd, f32 x, f32 y, f32 z)
     *(f32*)((char*)e + 0x1c) = spd;
     *(u8*)((char*)e + 0x2d) = b;
     *(int*)((char*)e + 0x10) = 0;
-    e14 = state + off;
-    *(int*)((char*)e14 + 0x14) = (int)(lbl_803E4930 * sqrtf(spd));
+    {
+        int life = (int)(lbl_803E4930 * sqrtf(spd));
+        e14 = state + off;
+        e14 |= e; /* keep 0x14 base in its own saved reg (mr r29,r31) */
+        *(int*)((char*)e14 + 0x14) = life;
+    }
     {
         int v = *(int*)((char*)e14 + 0x14);
         if (v < 0)
@@ -239,13 +243,14 @@ void fn_801B3DE4(int obj, u8 b, f32 spd, f32 x, f32 y, f32 z)
             }
         }
     }
-    *(s16*)((char*)state + idx * 0x30 + 0x28) = randomGetRange(0, 0xffff);
-    *(s16*)((char*)state + idx * 0x30 + 0x2a) = randomGetRange(0xc8, 0x12c);
+    /* group field offset onto base so each slot address re-derives (add state,off) per call */
+    *(s16*)((char*)((char*)state + 0x28) + idx * 0x30) = randomGetRange(0, 0xffff);
+    *(s16*)((char*)((char*)state + 0x2a) + idx * 0x30) = randomGetRange(0xc8, 0x12c);
     if ((int)randomGetRange(0, 1) != 0)
     {
-        *(s16*)((char*)state + idx * 0x30 + 0x2a) = -*(s16*)((char*)state + idx * 0x30 + 0x2a);
+        *(s16*)((char*)((char*)state + 0x2a) + idx * 0x30) = -*(s16*)((char*)((char*)state + 0x2a) + idx * 0x30);
     }
-    *(u8*)((char*)state + idx * 0x30 + 0x2c) = randomGetRange(0, 3);
+    *(u8*)((char*)((char*)state + 0x2c) + idx * 0x30) = randomGetRange(0, 3);
     {
         f32 sp = *(f32*)((char*)e + 0x1c);
         f32 ev = expf(
@@ -254,7 +259,7 @@ void fn_801B3DE4(int obj, u8 b, f32 spd, f32 x, f32 y, f32 z)
         f32 d = sp - *(f32*)((char*)e + 0x18);
         f32 t = d * ev;
         *(f32*)((char*)e + 0xc) = sp - gExplosionDebrisSpeedScale * t;
-        ev = expf((lbl_803E493C * (f32)(int) * (int*)((char*)e + 0x10)) / (f32)(e = (int) * (int*)((char*)e14 + 0x14)));
+        ev = expf((lbl_803E493C * (f32)(int) * (int*)((char*)e + 0x10)) / (f32)(int) * (int*)((char*)e14 + 0x14));
         t = lbl_803E4938 * ev;
         p = (char*)state;
         *(s8*)(p + idx * 0x30 + 0x2e) = lbl_803E4938 - gExplosionDebrisAlphaScale * t;


### PR DESCRIPTION
…lue merge

Closes the long-standing "uncrackable" residual byte-for-byte with two clean-C levers (no inline asm):

- `e14 |= e` (no-op; e == state+off) blocks the front-end value-number merge that folds the two identical state+off into one web, forcing the surviving `mr r29,r31` copy + a separate saved-reg web for the 0x14/lifetime base. Declare e14 first (-> r29); compute the lifetime to a temp first so the copy lands after sqrtf (matching position).
- Random section: group the field offset onto the base pointer `((char*)state + K) + idx*0x30` so each slot address re-derives per call with the correct `add state,off` operand order (recipe #112 K-grouping).

Docs/recipes: add CLAUDE.md #131; correct the worked example + #108/#130 framing ("open frontier / source-levers exhausted" was wrong); banner the old partial + handover as SOLVED; add fn_801B3DE4_SOLVED.md with the full method (structural- distance over fuzzy%, read the asm per variant).

No regressions: unit builds green, sibling fns still 100%, explosion_render unchanged at 99.77%.