### PR TITLE
model: 92.19% -> 92.29% (ObjModel_LoadModelData + modelLoadAnimations exact)

### DIFF
--- a/include/main/model.h
+++ b/include/main/model.h
@@ -485,7 +485,7 @@ void setGQR6_2(int a, int b, int c, int d);
 void modelApplyBoneTransforms(u8* srcVtx, u8* dstVtx, u16 vtxCount, u8* targetA, u8* targetB, int blendScale);
 void* modelLoad_layoutBuffers(u8* p, int b, int isType1, u8* c);
 void modelAnimResetState(void* m, void* data);
-int modelLoadAnimations(void* model, int id, void* animBase);
+int modelLoadAnimations(void* model, int modelId, u8* buf);
 void ObjModel_AdvanceBlendChannels(u8* model, f32 dt);
 void ObjModel_LoadRenderOpTextures(u8* model, GameObject* object);
 void ObjModel_Release(u8* model);

--- a/src/main/model.c
+++ b/src/main/model.c
@@ -505,10 +505,10 @@ void modelAnimResetState(void* m, void* data)
         channel->prevBlendCacheSlot = channel->moveCacheSlot;
     }
 }
-int modelLoadAnimations(void* model, int id, void* animBase)
+int modelLoadAnimations(void* model, int modelId, u8* buf)
 {
     int tabBase;
-    u8* buf = animBase;
+    int id = modelId;
     int* tbl;
     u8* hdr = model;
     int sz;

--- a/src/main/model.c
+++ b/src/main/model.c
@@ -2663,6 +2663,7 @@ void* ObjModel_LoadModelData(int id)
 {
     int fileOffset, dataLen, animCount, headerSize, amapFlag;
     int amapSize;
+    int allocSize;
     void* model;
     if (getTableFileEntry(MLDF_FILEID_MODELS_TAB_A, id, &fileOffset) == 0)
     {
@@ -2672,7 +2673,9 @@ void* ObjModel_LoadModelData(int id)
     headerSize = roundUpTo8(headerSize);
     headerSize += 0xb0;
     amapSize = modelGetAmapSize(id, amapFlag, animCount);
-    model = (void*)roundUpTo16((int)mmAlloc(dataLen + amapSize + 0x1f4, 9, 0));
+    allocSize = dataLen + amapSize + 0x1f4;
+    model = (void*)roundUpTo16((int)mmAlloc(allocSize, 9, 0));
+    DCInvalidateRange(model, allocSize);
     loadAndDecompressDataFile(MLDF_FILEID_MODELS_BIN_A, model, fileOffset, dataLen, 0, id, 0);
     ((ModelFileHeader*)model)->headerSize = headerSize;
     ((ModelFileHeader*)model)->modelId = id;


### PR DESCRIPTION
## What changed

Two small plain-C changes in `src/main/model.c` (plus a prototype update in `include/main/model.h`):

- `ObjModel_LoadModelData` — retail calls `DCInvalidateRange(model, allocSize)` on the freshly `mmAlloc`'d, 16-aligned model buffer before `loadAndDecompressDataFile` decompresses into it (the standard GC pattern before a DMA/decompress into a new buffer). The size is a named local `allocSize = dataLen + amapSize + 0x1f4` reused for both calls. **93.48% → 100%**
- `modelLoadAnimations` — the animation write cursor is the `u8*` parameter advanced in place (`buf += sz`), while the model id lives in a local `int id = modelId` later reused for the amap data size — matching the surrounding style (`hdr = model` local copy). Only a register-order difference. **99.66% → 100%**

## Evidence

- `main/main/model` fuzzy (report.json, GSAE01_rev1): **92.19% → 92.29%**, matched functions 73 → 75 of 85
- `ninja all_source progress build/GSAE01_rev1/report.json` exits 0
- Independently re-audited against `AGENTS.md`: no pragmas, no asm, no hardcoded addresses, no debris; only the two intended files touched

## Notes for review

- Verified locally on the **Rev 1** build (v1.01 is the dump I own); the changes are version-agnostic plain C and I'd expect the same result on v1.00 — CI will confirm.
- The unit's remaining gap is essentially walled: 7 functions are hand-written asm in retail (`modelApplyBoneTransform`/`modelBoneTransforms_next` custom register convention, `setGQR6/7` mtspr, the three paired-single `ObjModel_Transform*Vertices*` loops) — asm is banned outside `src/dolphin/`, so left as-is. `modelInitBoneMtxs`/`ObjModel_Blend*Stream` are pure nonvolatile register-order residue after ~10 clean-C shape experiments each.
- `clang-format --dry-run` fails on `model.c`, but every violation is pre-existing on `main` (whole-TU brace style); this diff introduces none, and reformatting the whole TU is out of scope here.

---
Produced by Claude agents following `AGENTS.md`, operated by @SirEnkido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
